### PR TITLE
Add aria-reflection.html and virtual-accessibility-nodes.html

### DIFF
--- a/spec/aria-reflection.html
+++ b/spec/aria-reflection.html
@@ -94,10 +94,8 @@
       This specification describes the additions to existing specifications which will make it possible for web authors to programmatically
       express Element semantics in two ways:
       <ul>
-        <li>
-          <em>reflected</em> as DOM attributes on Elements</li>
-        <li>
-          <em>non-reflected</em>, via a ShadowRoot.</li>
+        <li>as reflected IDL attributes on Elements, or</li>
+        <li>as non-reflected IDL attributes on an attached ShadowRoot.</li>
       </ul>
     </p>
   </section>
@@ -669,12 +667,12 @@ el.getAttribute("aria-label"); // Returns "Publish"</pre>
         <code>ShadowRoot</code>, or both.
       </p>
       <p>
-        If a
-        <code>role</code> or ARIA attribute property is set on
-        <em>either</em> the
-        <code>Element</code>
-        <em>or</em> its associated
-        <code>ShadowRoot</code>, that property should be
+        If an IDL property from either the
+        <code>AccessibilityRole</code> mixin or the
+        <code>AriaAttributes</code> mixin
+        is set on <em>either</em> the <code>Element</code>
+        <em>or</em> its associated <code>ShadowRoot</code>,
+        that IDL attribute should be
         <a href="https://www.w3.org/TR/core-aam-1.1/#mapping_general">mapped</a>
         to the
         <a href="https://www.w3.org/TR/core-aam-1.1/#dfn-accessible-object">accessible object</a>
@@ -683,7 +681,7 @@ el.getAttribute("aria-label"); // Returns "Publish"</pre>
         <code>Element</code>.
       </p>
       <p>
-        If a property is set on
+        If a property is set to a non-<code>null</code> value on
         <em>both</em> the
         <code>ShadowRoot</code>
         and the host

--- a/spec/aria-reflection.html
+++ b/spec/aria-reflection.html
@@ -1,0 +1,761 @@
+<!--?xml version='1.0' encoding='UTF-8'?-->
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+
+<head>
+  <title>AOM Phase 1 - ARIA reflection</title>
+  <meta content="text/html; charset=utf-8" http-equiv="Content-Type" />
+  <script src='https://www.w3.org/Tools/respec/respec-w3c-common' async class='remove'>
+  </script>
+  <script class='remove'>
+    /*Make tidy happy*/
+    var respecConfig = {
+      // specification status (e.g. WD, LCWD, WG-NOTE, etc.). If in doubt use ED.
+      specStatus: "unofficial",
+      // the specification's short name, as in http://www.w3.org/TR/short-name/
+      shortName: "aom",
+
+      // if your specification has a subtitle that goes below the main
+      // formal title, define it here
+      // subtitle   :  "an excellent document",
+
+      // if you wish the publication date to be other than the last modification, set this
+      // publishDate:  "2009-08-06",
+
+      // if the specification's copyright date is a range of years, specify
+      // the start date here:
+      // copyrightStart: "2005"
+
+      // if there is a previously published draft, uncomment this and set its YYYY-MM-DD date
+      // and its maturity status
+      // previousPublishDate:  "1977-03-15",
+      // previousMaturity:  "WD",
+
+      // if there a publicly available Editor's Draft, this is the link
+      // edDraftURI:           "http://berjon.com/",
+
+      // if this is a LCWD, uncomment and set the end of its review period
+      // lcEnd: "2009-08-05",
+
+      // editors, add as many as you like
+      // only "name" is required
+      editors: [{
+          name: "Alice Boxhall",
+          url: "http://google.com",
+          mailto: "aboxhall@google.com",
+          company: "Google",
+          companyURL: "http://google.com/"
+        },
+        {
+          name: "James Craig",
+          url: "http://apple.com",
+          mailto: "jcraig@apple.com",
+          company: "Apple",
+          companyURL: "http://apple.com/"
+        },
+        {
+          name: "Dominic Mazzoni",
+          url: "http://google.com",
+          mailto: "dmazzoni@google.com",
+          company: "Google",
+          companyURL: "http://google.com/"
+        },
+        {
+          name: "Alexander Surkov",
+          url: "http://mozilla.org/",
+          mailto: "surkov.alexander@gmail.com",
+          company: "Mozilla",
+          companyURL: "http://mozilla.org/"
+        },
+      ],
+      // name of the WG
+      //         wg:           "None",
+
+      // URI of the public WG page
+      //         wgURI:        "http://example.org/really-cool-wg",
+
+      // name (without the @w3c.org) of the public mailing to which comments are due
+      //          wgPublicList: "spec-writers-anonymous",
+
+      // URI of the patent status for this WG, for Rec-track documents
+      // !!!! IMPORTANT !!!!
+      // This is important for Rec-track documents, do not copy a patent URI from a random
+      // document unless you know what you're doing. If in doubt ask your friendly neighbourhood
+      // Team Contact.
+      //        wgPatentURI:  "",
+      // !!!! IMPORTANT !!!! MAKE THE ABOVE BLINK IN YOUR HEAD
+    };
+  </script>
+</head>
+
+<body>
+  <section id="abstract">
+    <p>
+      This specification describes the additions to existing specifications which will make it possible for web authors to programmatically
+      express Element semantics in two ways:
+      <ul>
+        <li>
+          <em>reflected</em> as DOM attributes on Elements</li>
+        <li>
+          <em>non-reflected</em>, via a ShadowRoot.</li>
+      </ul>
+    </p>
+  </section>
+  <section id="idl-interface" class="normative">
+    <h2>IDL Interface</h2>
+    <p class="note">This section is part of the
+      <a href="https://w3c.github.io/aria/#idl-interface">ARIA 1.2 Specification</a>, and is included here for informative purposes only.</p>
+
+    <p>Conforming user agents MUST implement the following IDL interfaces.</p>
+    <section id="AccessibilityRole" class="normative" data-dfn-for="AccessibilityRole" data-link-for="AccessibilityRole">
+      <h2>Interface Mixin
+        <dfn>AccessibilityRole</dfn>
+      </h2>
+      <pre class="idl">
+    interface mixin AccessibilityRole {
+    attribute DOMString? role;
+    };
+    Element includes AccessibilityRole;
+          ShadowRoot includes AccessibilityRole;
+  </pre>
+      <section id="role-reflection" class="normative">
+        <h2>ARIA Role Reflection</h2>
+        <p>User agents MUST
+          <a href="https://www.w3.org/TR/html52/infrastructure.html#reflecting-content-attributes-in-idl-attributes">reflect</a> the
+          <code>
+            <dfn>role</dfn>
+          </code> content attribute as the
+          <code>role</code> IDL attribute on
+          <code>Element</code> instances.</p>
+      </section>
+    </section>
+    <section id="AriaAttributes" class="normative" data-dfn-for="AriaAttributes" data-link-for="AriaAttributes">
+      <h2>Interface Mixin
+        <dfn>AriaAttributes</dfn>
+      </h2>
+      <pre class="idl">
+    interface mixin AriaAttributes {
+    attribute DOMString? ariaActiveDescendant;
+    attribute DOMString? ariaAtomic;
+    attribute DOMString? ariaAutoComplete;
+    attribute DOMString? ariaBusy;
+    attribute DOMString? ariaChecked;
+    attribute DOMString? ariaColCount;
+    attribute DOMString? ariaColIndex;
+    attribute DOMString? ariaColSpan;
+    attribute DOMString? ariaControls;
+    attribute DOMString? ariaCurrent;
+    attribute DOMString? ariaDescribedBy;
+    attribute DOMString? ariaDetails;
+    attribute DOMString? ariaDisabled;
+    attribute DOMString? ariaErrorMessage;
+    attribute DOMString? ariaExpanded;
+    attribute DOMString? ariaFlowTo;
+    attribute DOMString? ariaHasPopup;
+    attribute DOMString? ariaHidden;
+    attribute DOMString? ariaInvalid;
+    attribute DOMString? ariaKeyShortcuts;
+    attribute DOMString? ariaLabel;
+    attribute DOMString? ariaLabelledBy;
+    attribute DOMString? ariaLevel;
+    attribute DOMString? ariaLive;
+    attribute DOMString? ariaModal;
+    attribute DOMString? ariaMultiLine;
+    attribute DOMString? ariaMultiSelectable;
+    attribute DOMString? ariaOrientation;
+    attribute DOMString? ariaOwns;
+    attribute DOMString? ariaPlaceholder;
+    attribute DOMString? ariaPosInSet;
+    attribute DOMString? ariaPressed;
+    attribute DOMString? ariaReadOnly;
+    attribute DOMString? ariaRelevant;
+    attribute DOMString? ariaRequired;
+    attribute DOMString? ariaRoleDescription;
+    attribute DOMString? ariaRowCount;
+    attribute DOMString? ariaRowIndex;
+    attribute DOMString? ariaRowSpan;
+    attribute DOMString? ariaSelected;
+    attribute DOMString? ariaSetSize;
+    attribute DOMString? ariaSort;
+    attribute DOMString? ariaValueMax;
+    attribute DOMString? ariaValueMin;
+    attribute DOMString? ariaValueNow;
+    attribute DOMString? ariaValueText;
+    };
+    Element includes AriaAttributes;
+          ShadowRoot includes AriaAttributes;
+  </pre>
+      <section id="attribute-reflection" class="normative">
+        <h2>ARIA Attribute Reflection</h2>
+        <p>User agents MUST
+          <a href="https://www.w3.org/TR/html52/infrastructure.html#reflecting-content-attributes-in-idl-attributes">reflect</a> the following content attributes to each of the corresponding IDL attributes on
+          <code>Element</code> instances.</p>
+        <table>
+          <tr>
+            <th>IDL Attribute</th>
+            <th>Reflected ARIA Content Attribute</th>
+          </tr>
+          <tr>
+            <td>
+              <dfn>ariaActiveDescendant</dfn>
+            </td>
+            <td>
+              <pref>aria-activedescendant</pref>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <dfn>ariaAtomic</dfn>
+            </td>
+            <td>
+              <pref>aria-atomic</pref>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <dfn>ariaAutoComplete</dfn>
+            </td>
+            <td>
+              <pref>aria-autocomplete</pref>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <dfn>ariaBusy</dfn>
+            </td>
+            <td>
+              <sref>aria-busy</sref>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <dfn>ariaChecked</dfn>
+            </td>
+            <td>
+              <sref>aria-checked</sref>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <dfn>ariaColCount</dfn>
+            </td>
+            <td>
+              <pref>aria-colcount</pref>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <dfn>ariaColIndex</dfn>
+            </td>
+            <td>
+              <pref>aria-colindex</pref>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <dfn>ariaColSpan</dfn>
+            </td>
+            <td>
+              <pref>aria-colspan</pref>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <dfn>ariaControls</dfn>
+            </td>
+            <td>
+              <pref>aria-controls</pref>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <dfn>ariaCurrent</dfn>
+            </td>
+            <td>
+              <sref>aria-current</sref>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <dfn>ariaDescribedBy</dfn>
+            </td>
+            <td>
+              <pref>aria-describedby</pref>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <dfn>ariaDetails</dfn>
+            </td>
+            <td>
+              <pref>aria-details</pref>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <dfn>ariaDisabled</dfn>
+            </td>
+            <td>
+              <sref>aria-disabled</sref>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <dfn>ariaErrorMessage</dfn>
+            </td>
+            <td>
+              <pref>aria-errormessage</pref>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <dfn>ariaExpanded</dfn>
+            </td>
+            <td>
+              <sref>aria-expanded</sref>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <dfn>ariaFlowTo</dfn>
+            </td>
+            <td>
+              <pref>aria-flowto</pref>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <dfn>ariaHasPopup</dfn>
+            </td>
+            <td>
+              <pref>aria-haspopup</pref>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <dfn>ariaHidden</dfn>
+            </td>
+            <td>
+              <sref>aria-hidden</sref>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <dfn>ariaInvalid</dfn>
+            </td>
+            <td>
+              <sref>aria-invalid</sref>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <dfn>ariaKeyShortcuts</dfn>
+            </td>
+            <td>
+              <pref>aria-keyshortcuts</pref>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <dfn>ariaLabel</dfn>
+            </td>
+            <td>
+              <pref>aria-label</pref>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <dfn>ariaLabelledBy</dfn>
+            </td>
+            <td>
+              <pref>aria-labelledby</pref>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <dfn>ariaLevel</dfn>
+            </td>
+            <td>
+              <pref>aria-level</pref>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <dfn>ariaLive</dfn>
+            </td>
+            <td>
+              <pref>aria-live</pref>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <dfn>ariaModal</dfn>
+            </td>
+            <td>
+              <pref>aria-modal</pref>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <dfn>ariaMultiLine</dfn>
+            </td>
+            <td>
+              <pref>aria-multiline</pref>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <dfn>ariaMultiSelectable</dfn>
+            </td>
+            <td>
+              <pref>aria-multiselectable</pref>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <dfn>ariaOrientation</dfn>
+            </td>
+            <td>
+              <pref>aria-orientation</pref>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <dfn>ariaOwns</dfn>
+            </td>
+            <td>
+              <pref>aria-owns</pref>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <dfn>ariaPlaceholder</dfn>
+            </td>
+            <td>
+              <pref>aria-placeholder</pref>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <dfn>ariaPosInSet</dfn>
+            </td>
+            <td>
+              <pref>aria-posinset</pref>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <dfn>ariaPressed</dfn>
+            </td>
+            <td>
+              <sref>aria-pressed</sref>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <dfn>ariaReadOnly</dfn>
+            </td>
+            <td>
+              <pref>aria-readonly</pref>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <dfn>ariaRelevant</dfn>
+            </td>
+            <td>
+              <pref>aria-relevant</pref>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <dfn>ariaRequired</dfn>
+            </td>
+            <td>
+              <pref>aria-required</pref>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <dfn>ariaRoleDescription</dfn>
+            </td>
+            <td>
+              <pref>aria-roledescription</pref>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <dfn>ariaRowCount</dfn>
+            </td>
+            <td>
+              <pref>aria-rowcount</pref>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <dfn>ariaRowIndex</dfn>
+            </td>
+            <td>
+              <pref>aria-rowindex</pref>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <dfn>ariaRowSpan</dfn>
+            </td>
+            <td>
+              <pref>aria-rowspan</pref>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <dfn>ariaSelected</dfn>
+            </td>
+            <td>
+              <sref>aria-selected</sref>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <dfn>ariaSetSize</dfn>
+            </td>
+            <td>
+              <pref>aria-setsize</pref>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <dfn>ariaSort</dfn>
+            </td>
+            <td>
+              <pref>aria-sort</pref>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <dfn>ariaValueMax</dfn>
+            </td>
+            <td>
+              <pref>aria-valuemax</pref>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <dfn>ariaValueMin</dfn>
+            </td>
+            <td>
+              <pref>aria-valuemin</pref>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <dfn>ariaValueNow</dfn>
+            </td>
+            <td>
+              <pref>aria-valuenow</pref>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <dfn>ariaValueText</dfn>
+            </td>
+            <td>
+              <pref>aria-valuetext</pref>
+            </td>
+          </tr>
+        </table>
+        <p class="note">Note: Attributes
+          <pref>aria-dropeffect</pref> and
+          <sref>aria-grabbed</sref> were deprecated in ARIA 1.1 and do not have corresponding IDL attributes.</p>
+      </section>
+      <section class="informative" id="idl_attr_disambiguation">
+        <h3>Disambiguation Pattern</h3>
+        <p>Though specification authors may make exceptions to this pattern, the following rules were used to disambiguate names
+          and case of the IDL attributes listed above.</p>
+        <ul>
+          <li>Any attribute name referencing concepts that are combinations of two or more words (such as "described by") becomes
+            a camel-cased IDL attribute capitalizing each word boundary. For example,
+            <pref>aria-describedby</pref> becomes
+            <code>ariaDescribedBy</code> with both the D and B capitalized.</li>
+          <li>Likewise, any attribute name referencing concepts that can be hyphenated (such as "multi-selectable") becomes a camel-cased
+            IDL attribute capitalizing each hyphenation boundary. For example, the only valid spelling for "multi-selectable" is
+            hyphenated, so
+            <pref>aria-multiselectable</pref> becomes
+            <code>ariaMultiSelectable</code> with both the M and S capitalized.</li>
+          <li>When trusted dictionary sources list both hyphenated or non-hyphenated spellings (e.g. "multi-line" and "multiline"
+            are both valid spellings) use the hyphenated version and apply the hyphenation rule above. For example,
+            <pref>aria-multiline</pref> becomes
+            <code>ariaMultiLine</code> with both the M and L capitalized.</li>
+          <li>If all trusted dictionary sources list a single spelling of a compound word with no spaces or hyphens, only the first
+            letter of the term is capitalized. For example, neither “place-holder” nor “place holder” are considered valid spellings
+            of the term “placeholder,” so
+            <pref>aria-placeholder</pref> becomes
+            <code>ariaPlaceholder</code> with only the P capitalized.</li>
+          <li>There are currently no acronym-based ARIA attributes, but if future attributes include acronym usage, attempt to match
+            existing DOM conventions (e.g. ID becomes Id).</li>
+        </ul>
+      </section>
+      <section class="informative" id="idl_attr_exceptions">
+        <h3>IDL Attribute Name Notes or Exceptions</h3>
+        <p>Any notes or exceptions for specific attribute names will be listed here.</p>
+        <ul>
+          <li>
+            <code>ariaPosInSet</code>: The
+            <pref>aria-posinset</pref> attribute refers to an item's position in a set (two words: "in set") rather than the "inset"
+            of an item from the beginning of the collection. Therefore the IDL attribute name is
+            <code>ariaPosInSet</code> with the P, I, and second S capitalized,
+            <em>not</em>
+            <code>ariaPosInset</code>.</li>
+        </ul>
+        <p class="ednote">Editor's Note: Should we make an exception on the spelling of "placeholder" and capitalize the H anyway? Some developers
+          will expect this to be
+          <code>ariaPlaceHolder</code> despite the fact that it's not a hyphenated word.</p>
+      </section>
+    </section>
+
+    <section class="informative" id="idl_example_usage">
+      <h2>Example IDL Attribute Usage</h2>
+      <p>The primary purpose of ARIA IDL attribute reflection is to ease JavaScript-based manipulation of values. The following
+        examples demonstrate its usage.</p>
+      <aside class="example">
+
+        <!-- ReSpec needs these examples to be unindented. -->
+        <pre>&lt;div id="inaccessibleButton"&gt;
+    &lt;!-- Use semantic markup instead. This is just a retrofit example. --&gt;
+&lt;/div&gt;</pre>
+        <pre>// Get a reference to the element.
+let el = document.getElementById('inaccessibleButton'); 
+el.tabIndex = 0; // Make it focusable.
+
+// Set the role and label.
+el.role = "button";
+el.ariaLabel = "Edit";
+
+// Get the role and label.
+el.role; // Returns "button"
+el.ariaLabel; // Returns "Edit"
+
+// These are interchangeable with the more verbose setAttribute and getAttribute methods.
+el.setAttribute("role", "button");
+el.setAttribute("aria-label", "Edit");
+el.getAttribute("role"); // Returns "button"
+el.getAttribute("aria-label"); // Returns "Edit"
+
+// Changes via either interface are reflected by the other.
+el.setAttribute("aria-label", "Delete");
+el.ariaLabel; // Returns "Delete"
+el.ariaLabel = "Publish";
+el.getAttribute("aria-label"); // Returns "Publish"</pre>
+
+      </aside>
+    </section>
+
+    <section class="normative" id="shadowroot_interaction">
+      <h2>Interaction between
+        <code>ShadowRoot</code> and
+        <code>host</code>
+      </h2>
+      <p>If an
+        <code>Element</code> has an attached
+        <code>ShadowRoot</code>, and the author has access to the
+        <code>ShadowRoot</code>, authors may set a
+        <code>role</code> or ARIA attribute, such as
+        <a href="#dom-ariaattributes-ariaactivedescendant">
+          <code>ariaActivedescendant</code>
+        </a>, on
+        <em>either</em> the
+        <code>Element</code>,
+        <em>or</em> the
+        <code>ShadowRoot</code>, or both.
+      </p>
+      <p>
+        If a
+        <code>role</code> or ARIA attribute property is set on
+        <em>either</em> the
+        <code>Element</code>
+        <em>or</em> its associated
+        <code>ShadowRoot</code>, that property should be
+        <a href="https://www.w3.org/TR/core-aam-1.1/#mapping_general">mapped</a>
+        to the
+        <a href="https://www.w3.org/TR/core-aam-1.1/#dfn-accessible-object">accessible object</a>
+        <a href="https://www.w3.org/TR/core-aam-1.1/#include_elements">associated</a>
+        with the host
+        <code>Element</code>.
+      </p>
+      <p>
+        If a property is set on
+        <em>both</em> the
+        <code>ShadowRoot</code>
+        and the host
+        <code>Element</code>, the reflected value on the host
+        <code>Element</code> takes precedence,
+        i.e. the reflected <code>role</code> value on the host <code>Element</code>
+        is used to compute the
+        <a href="https://www.w3.org/TR/core-aam-1.1/#mapping_role">mapped role</a>
+        in the
+        <a href="https://www.w3.org/TR/core-aam-1.1/#dfn-accessibility-tree">accessibility tree</a>,
+        regardless of the value of the <code>role</code> value on the associated
+        <code>ShadowRoot</code>,
+        and similarly for all ARIA attribute properties.
+      </p>
+      <aside class="example">
+        <p>
+          For example, an author creating a
+          <a href="https://html.spec.whatwg.org/multipage/#custom-elements">Custom Element</a>
+          may use a
+          <code>ShadowRoot</code> to encapsulate implementation details for the element.
+        </p>
+        <p>
+          They may use the
+          <code>ShadowRoot</code> to encode certain "default" values for the ARIA
+          <code>role</code> and properties for the element, which an author using the Custom Element may choose to override using reflected
+          ARIA properties.
+        </p>
+        <pre>
+class CustomCheckbox extends HTMLElement {
+
+  // ...
+
+  constructor() {
+    super();
+    this.attachShadow({mode: 'open'});  // mode may also be "closed".
+
+    // ... any other set-up
+  }
+
+  connectedCallback() {
+    // Set the default semantics for the custom element
+    // when it is inserted in the page.
+    this.shadowRoot.role = "checkbox";
+  }
+
+  // Observe the custom "checked" attribute
+  static get observedAttributes() { return ["checked"]; }
+
+  // ... setters/getters for properties which reflect to attributes
+
+  // When the custom "checked" attribute changes,
+  // keep the accessible checked state in sync.
+  attributeChangedCallback(name, oldValue, newValue) {
+  switch(name) {
+    case "checked":
+      this.shadowRoot.ariaChecked = (newValue !== null);
+    }
+  }
+}
+
+customElements.define("custom-checkbox", CustomCheckbox);
+</pre>
+        <p>An author using the Custom Element could then use
+          the reflected ARIA properties/content attributes to override the default values,
+          just as they would when using a native element:</p>
+<pre>
+&lt;!-- ARIA role overrides Shadow DOM role --&gt;
+&lt;custom-checkbox role="radio"&gt;
+</pre>
+      </aside>
+    </section>
+  </section>
+</body>
+
+</html>

--- a/spec/computed-accessibility-tree.html
+++ b/spec/computed-accessibility-tree.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <title>
-      Accessibility Object Model, Phase 3
+      Accessibility Object Model, Phase 4
     </title>
     <meta charset='utf-8'>
     <script src='https://www.w3.org/Tools/respec/respec-w3c-common' async
@@ -89,57 +89,45 @@
       };
     </script>
   </head>
-    <section id="abstract">
-      <p class="warning">
-        This spec has been deprecated,
-        please see the
-        <a href="https://github.com/WICG/aom/blob/master/explainer.md">Accessibility Object Model Explainer</a>
-        and
-        <a href="index.html">index to specs</a>
-        for up to date information.
-      </p>
-    </section>
   <body>
-    <section id="introduction">
-      <h1>Introduction</h1>
-      <p>
-        This document is the spec for Phase 3 of the Accessibility Object
-        Model spec. For background, please refer to the
-        <a href="https://github.com/WICG/aom/blob/master/explainer.md">
-          Accessibility Object Model Explainer</a> for the background and
-        motivation, and then
-        <a href="index.html">Phase 1</a> and
-        <a href="phase2.html">Phase 2</a>.
-      </p>
+    <section id="abstract">
+    <p>
+      This document is a placeholder for
+      the spec for "Accessibility Tree Introspection",
+      a part of the AOM project.
+      For background, please refer to the
+      <a href="https://github.com/WICG/aom/blob/master/explainer.md">Accessibility Object Model Explainer</a>.
+    </p>
     </section>
-    <section class="virtual">
-      <h2>
-        Phase 3: Virtual Accessibility Nodes
-      </h2>
-      <p>
-        Virtual Accessibility Nodes will allow authors to expose
-        "virtual" accessibility nodes, which are not associated directly
-        with any particular DOM node, to assistive technology.
-      </p>
-      <p>
-        This mechanism is often present in native accessibility APIs,
-        in order to allow authors more granular control over the
-        accessibility of custom-drawn APIs.
-      </p>
-      <p>
-        On the web, this would allow creating an accessible solution
-        to canvas-based UI which does not rely on fallback or
-        visually-hidden DOM content.
-      </p>
-      <p>
-        The API for Virtual Accessibility Nodes will be specified at a later date.
-      </p>
-    </section>
-    <section id="actions">
+    <section id="computedtree">
       <h2>
         Phase 4: Computed Accessibility Tree
       </h2>
-      <p>See <a href="phase4.html">Phase 4</a></p>
+      <p>
+        The Computed Accessibility Tree API will allow authors to
+        access the full computed accessibility tree - all computed
+        properties for the accessibility node associated with each
+        DOM node, plus the ability to walk the computed tree
+        structure including virtual nodes.
+      </p>
+      <p>
+        This will make it possible to:
+      </p>
+      <ul>
+        <li>write any programmatic test which asserts anything about the semantic properties of an element or a page.
+        <li>build a reliable browser-based assistive technology - for example, a browser extension which uses the accessibility tree to implement a screen reader, screen magnifier, or other assistive functionality; or an in-page tool.
+        <li>detect whether an accessibility property has been successfully applied (via ARIA or otherwise) to an element - for example, to detect whether a browser has implemented a particular version of ARIA.
+        <li>do any kind of console-based debugging/checking of accessibility tree issues.
+          react to accessibility tree state, for example, detecting the exposed role of an element and modifying the accessible help text to suit.
+      </ul>
+      <p>
+        One implication of implementing this phase is that all browsers must agree on
+        exposing the *same* accessibility tree for the same given webpage, otherwise
+        differences will invariably lead to authored pages that work in some browsers
+        but not others. Care must be taken to define this phase in such a way that
+        maintains a high degree of compatibility between browsers, without exposing any
+        internal details and nuances.
+      </p>
     </section>
   </body>
 </html>

--- a/spec/index.html
+++ b/spec/index.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <title>
-      Accessibility Object Model, Phase 1
+      Accessibility Object Model
     </title>
     <meta charset='utf-8'>
     <script src='https://www.w3.org/Tools/respec/respec-w3c-common' async
@@ -123,16 +123,44 @@
   <body>
     <section id='abstract'>
       <p>
-        This specification provides a way for authors to make web apps
-        accessible using scripting, rather than the only option being
-        declarative accessibility features of HTML markup. In the
-        first phase, the author is able to programmatically
-        modify the accessible representation of an existing DOM
-        element. In future phases, the author is able to respond to
-        additional input events from assistive technology,
-        create new virtual accessible objects on the page that don't
-        correspond to an HTML element at all, and explore the computed
-        accessibility tree.
+        The Accessibility Object Model project aims to improve
+        certain aspects of the user and developer experiences
+        concerning the interaction between web pages and
+        <a href="https://www.w3.org/TR/core-aam-1.1/#dfn-assistive-technology">assistive technology</a>.
+      </p>
+      <p>
+        In particular, this project is concerned wtih improving the developer experience around:
+        <ul>
+          <li>building <a href="https://www.webcomponents.org/introduction">Web Components</a>
+            which are as accessible as a
+            <a href="https://html.spec.whatwg.org/#semantics">built-in element</a>;
+          </li>
+          <li>expressing and modifying the
+            <a href="https://www.w3.org/TR/core-aam-1.1/#dfn-semantics">semantics</a>
+            of any <code>Element</code> using DOM APIs;
+          </li>
+          <li>expressing
+            <a href="https://www.w3.org/TR/core-aam-1.1/#dfn-relationship">semantic relationships</a>
+            between <code>Element</code>s;
+          </li>
+          <li>expressing <a href="https://www.w3.org/TR/core-aam-1.1/#dfn-semantics">semantics</a>
+            for visual user interfaces which are not composed of <code>Element</code>s,
+            such as <a href="https://html.spec.whatwg.org/multipage/scripting.html#the-canvas-element"><code>canvas</code></a>-based user interfaces;
+          </li>
+          <li>understanding and testing the process by which
+            <a href="https://w3c.github.io/html-aam/#mapping-html-to-accessibility-apis">HTML</a>
+            and
+            <a href="https://www.w3.org/TR/core-aam-1.1/#mapping_conflicts">ARIA</a>
+            contribute to the computation of the
+            <a href="https://www.w3.org/TR/core-aam-1.1/#dfn-accessibility-tree">accessibility tree</a>.
+          </li>
+        </ul>
+      </p>
+      <p>
+        By reducing the friction experienced by developers in creating accessible web pages,
+        and filling in gaps in what semantics may be expressed via DOM APIs,
+        the APIs proposed in the Accessibility Objet Model aim to improve
+        the user experience of users interacting with web pages via assistive technology.
       </p>
     </section>
     <section id="introduction" class="informative">
@@ -149,502 +177,67 @@
           <a href="https://github.com/WICG/aom/issues">file an issue</a> on GitHub.
         </p>
       </section>
+      <section id="structure">
+        <h2>Structure of Accessibility Object Model Specs</h2>
+        <p>
+          The specifications which comprise the Accessibility Object Model
+          are split into loose "phases",
+          each of which may take the form of a modification to an existing spec,
+          or a new API.
+        </p>
+        <p>
+          While the term "phases" indicates a rough ordering,
+          based on expected time to completion
+          and relative urgency of work,
+          it should not be expected that one phase must be complete
+          before work begins on the next,
+          nor that phases will be completed in strict order.
+        </p>
+        <p>
+          See the <a href="#phases">project phases</a> section for links to each phase.
+        </p>
+      </section>
       <section id="scope">
         <h2>Document Scope</h2>
-        <p>The Accessibility Object Model spec is narrowly focused on the goal of creating a scripting API for web accessibility. It's intended to complement existing web accessibility APIs such as [[!WAI-ARIA]], not replace them. In particular, this spec attempts to avoid proposing new roles, states, and properties an of accessible objects except where necessary.</p>
+        <p>The Accessibility Object Model specs are narrowly focused on the goals described in the Abstract.
+          They are intended to complement existing web accessibility APIs
+          such as [[!WAI-ARIA]],
+          not replace them.
+          In particular, this spec attempts to avoid proposing
+          new roles, states, and properties of accessible objects except where necessary.</p>
       </section>
       <section id="inclusion">
         <h2>Criteria for Inclusion</h2>
-        <p>This specification is not intended to solve all accessibility problems on the Web. It is currently impossible to make some web features accessible, so the primary goal is to resolve immediate needs quickly for existing, inaccessible web interfaces. The specification editors are purposefully deferring many useful ideas in order to maintain a realistic timeline for highest priority features.</p>
+        <p>This specification is not intended to solve all accessibility problems on the Web.
+          It is currently impossible to make some web features accessible,
+          so the primary goal is to resolve immediate needs quickly for existing,
+          inaccessible web interfaces.
+          The specification editors are intentionally deferring many useful ideas
+          in order to maintain a realistic timeline for highest priority features.</p>
         <p>
           We have defined <a href="criteria.html">Inclusion/Exclusion Criteria</a>
           in order to clarify exactly what will be considered in-scope.
         </p>
       </section>
     </section>
-    <section id="properties">
-      <h2>
-        Phase 1: Accessible Properties
-      </h2>
-      <section>
-        <h3>
-          Extensions to the <code>Element</code> interface
-        </h3>
-        <p>
-          The author can request an <i>accessible node</i> from any valid [[!DOM]]
-          <code>Element</code>.
-        </p>
-        <pre class="idl">
-          partial interface Element {
-            readonly attribute AccessibleNode accessibleNode;
-          };
-        </pre>
-        <p data-dfn-for="Element">
-          The <dfn>accessibleNode</dfn> attribute returns the <i>accessible
-          node</i> associated with this <code>DOM element</code>. It always returns
-          a valid object if the browser supports the AOM.
-        </p>
+    <section id="phases">
+      <h2>Phases</h2>
+      <section id="aria-reflection">
+        <h2>Phase 1: ARIA Reflection</h2>
+        <p>See the <a href="aria-reflection.html">ARIA Reflection</a> document.</p>
       </section>
-      <section id="accessiblenode">
-        <h3>
-          <code>AccessibleNode</code> interface
-        </h3>
-        <pre class="idl">
-        interface AccessibleNode {
-          attribute DOMString? role;
-          attribute DOMString? roleDescription;
-
-          // Accessible label and description.
-          attribute DOMString? label;
-          attribute AccessibleNodeList? labeledBy;
-          attribute AccessibleNodeList? describedBy;
-
-          // Global states and properties.
-          attribute DOMString? current;
-
-          // Widget properties.
-          attribute DOMString? autocomplete;
-          attribute boolean? hidden;
-          attribute DOMString? keyShortcuts;
-          attribute boolean? modal;
-          attribute boolean? multiline;
-          attribute boolean? multiselectable;
-          attribute DOMString? orientation;
-          attribute boolean? readOnly;
-          attribute boolean? required;
-          attribute boolean? selected;
-          attribute DOMString? sort;
-
-          // Widget states.
-          attribute DOMString? checked;
-          attribute boolean? expanded;
-          attribute boolean? disabled;
-          attribute DOMString? invalid;
-          attribute DOMString? hasPopUp;
-          attribute DOMString? pressed;
-
-          // Control values.
-          attribute DOMString? valueText;
-          attribute DOMString? placeholder;
-          attribute double? valueNow;
-          attribute double? valueMin;
-          attribute double? valueMax;
-
-          // Live regions.
-          attribute boolean? atomic;
-          attribute boolean? busy;
-          attribute DOMString? live;
-          attribute DOMString? relevant;
-
-          // Other relationships.
-          attribute AccessibleNode? activeDescendant;
-          attribute AccessibleNodeList? controls;
-          attribute AccessibleNode? details;
-          attribute AccessibleNode? errorMessage;
-          attribute AccessibleNodeList? flowTo;
-          attribute AccessibleNodeList? owns;
-
-          // Collections.
-          attribute long? colCount;
-          attribute unsigned long? colIndex;
-          attribute unsigned long? colSpan;
-          attribute unsigned long? posInSet;
-          attribute long? rowCount;
-          attribute unsigned long? rowIndex;
-          attribute unsigned long? rowSpan;
-          attribute long? setSize;
-          attribute unsigned long? level;
-        };
-        </pre>
-        <p>
-          Initially all AccessibleNode properties must return null.
-        </p>
-        <p>
-          All AccessibleNode properties, on setting, store the provided value.
-          On getting, they return the user-provided value if present and valid,
-          and null otherwise. The validity of a property valid is specified in
-          greater detail below.
-        </p>
-        <p>
-          Values set on a DOM element's AccessibleNode are used
-          for the browser's implementation of native accessibility APIs for
-          that accessibility property.
-          When both an AccessibleNode property and its equivalent ARIA attribute
-          are both present, the ARIA attribute overrides the AccessibleNode
-          property.
-        </p>
-        <p>
-          If a property of AccessibleNode is set to an invalid value, it is ignored.
-        </p>
+      <section id="user-action-events">
+        <h2>Phase 2: User Action Events</h2>
+        <p>See the <a href="user-action-events.html">User Action Events</a> document.</p>
       </section>
-      <section>
-        <h3>
-          <code>AccessibleNodeList</code> interface
-        </h3>
-        <p>
-          An <code>AccessibleNodeList</code> represents an ordered
-          list of AccessibleNodes.
-          It's used to represent relationships between one
-          <code>AccessibleNode</code> and other
-          <code>AccessibleNodes</code> in the accessibility tree.
-          Unlike <code>AccessibleNode</code>, <code>AccessibleNodeList</code>
-          has a constructor.
-        </p>
-        <pre class="idl">
-        [
-          Constructor(optional sequence&lt;AccessibleNode&gt; nodes = [])
-        ]
-        interface AccessibleNodeList {
-          attribute unsigned long length;
-          getter AccessibleNode? item(unsigned long index);
-          setter void (unsigned long index, AccessibleNode node);
-          void add(AccessibleNode node, optional AccessibleNode? before = null);
-          void remove(long index);
-        };
-        </pre>
+      <section id="virtual-accessibility-nodes">
+        <h2>Phase 3: Virtual Accessibility Nodes</h2>
+        <p>See the <a href="virtual-accessibility-nodes.html">Virtual Accessibility Nodes</a> document.</p>
       </section>
-      <section id="mapping">
-        <h3>
-          Mapping to ARIA attributes
-        </h3>
-        <p>
-          In Phase 1, there's a 1:1 correspondence between the set of
-          properties on AccessibleNode and the list of valid ARIA
-          attributes from the [[!WAI-ARIA]] 1.1 spec.
-          This table shows the mappings and also includes deprecated
-          ARIA attributes that are not mapped into AccessibleNode
-          properties.
-        </p>
-        <p>
-          The Accessibility Object Model does not define new semantics.
-          The semantic meaning of each AccessibleNode property
-          is identical to the meaning of the ARIA attribute.
-        </p>
-      <table>
-        <caption>
-          <dfn>Accessibility property table</dfn>
-        </caption>
-        <thead>
-          <tr>
-            <th>Attribute name</th>
-            <th>Type</th>
-            <th>Equivalent ARIA attribute</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td><code>activeDescendant</code></td>
-            <td><code>AccessibleNode?</code></td>
-            <td><code>aria-activedescendant</code></td>
-          </tr>
-          <tr>
-            <td><code>atomic</code></td>
-            <td><code>boolean?</code></td>
-            <td><code>aria-atomic</code></td>
-          </tr>
-          <tr>
-            <td><code>autocomplete</code></td>
-            <td><code>DOMString?</code></td>
-            <td><code><nobr>aria-autocomplete</nobr></code></td>
-          </tr>
-          <tr>
-            <td><code>busy</code></td>
-            <td><code>boolean?</code></td>
-            <td><code>aria-busy</code></td>
-          </tr>
-          <tr>
-            <td><code>checked</code></td>
-            <td><code>DOMString?</code></td>
-            <td><code><nobr>aria-checked</nobr></code></td>
-          </tr>
-          <tr>
-            <td><code>colCount</code></td>
-            <td><code>long?</code></td>
-            <td><code><nobr>aria-colcount</nobr></code></td>
-          </tr>
-          <tr>
-            <td><code>colIndex</code></td>
-            <td><code>unsigned long?</code></td>
-            <td><code><nobr>aria-colindex</nobr></code></td>
-          </tr>
-          <tr>
-            <td><code>colSpan</code></td>
-            <td><code>unsigned long?</code></td>
-            <td><code><nobr>aria-colSpan</nobr></code></td>
-          </tr>
-          <tr>
-            <td><code>controls</code></td>
-            <td><code>AccessibleNodeList?</code></td>
-            <td><code>aria-controls</code></td>
-          </tr>
-          <tr>
-            <td><code>current</code></td>
-            <td><code>DOMString?</code></td>
-            <td><code><nobr>aria-current</nobr></code></td>
-          </tr>
-          <tr>
-            <td><code>describedBy</code></td>
-            <td><code>AccessibleNodeList?</code></td>
-            <td><code>aria-describedby</code></td>
-          </tr>
-          <tr>
-            <td><code>details</code></td>
-            <td><code>AccessibleNode?</code></td>
-            <td><code>aria-details</code></td>
-          </tr>
-          <tr>
-            <td><code>disabled</code></td>
-            <td><code>boolean?</code></td>
-            <td><code><nobr>aria-disabled</nobr></code></td>
-          </tr>
-          <tr>
-            <td></td>
-            <td></td>
-            <td><code><nobr>aria-dropeffect</nobr></code>
-              (deprecated)
-            </td>
-          </tr>
-          <tr>
-            <td><code>errorMessage</code></td>
-            <td><code>AccessibleNode?</code></td>
-            <td><code>aria-errormessage</code></td>
-          </tr>
-          <tr>
-            <td><code>expanded</code></td>
-            <td><code>boolean?</code></td>
-            <td><code><nobr>aria-expanded</nobr></code></td>
-          </tr>
-          <tr>
-            <td><code>flowTo</code></td>
-            <td><code>AccessibleNodeList?</code></td>
-            <td><code>aria-flowto</code></td>
-          </tr>
-          <tr>
-            <td></td>
-            <td></td>
-            <td><code><nobr>aria-grabbed</nobr></code>
-              (deprecated)
-            </td>
-          </tr>
-          <tr>
-            <td><code>hasPopUp</code></td>
-            <td><code>DOMString?</code></td>
-            <td><code><nobr>aria-haspopup</nobr></code></td>
-          </tr>
-          <tr>
-            <td><code>hidden</code></td>
-            <td><code>boolean?</code></td>
-            <td><code><nobr>aria-hidden</nobr></code></td>
-          </tr>
-          <tr>
-            <td><code>invalid</code></td>
-            <td><code>DOMString?</code></td>
-            <td><code><nobr>aria-invalid</nobr></code></td>
-          </tr>
-          <tr>
-            <td><code>keyShortcuts</code></td>
-            <td><code>DOMString?</code></td>
-            <td><code><nobr>aria-keyshortcuts</nobr></code></td>
-          </tr>
-          <tr>
-            <td><code>label</code></td>
-            <td><code>DOMString?</code></td>
-            <td><code><nobr>aria-label</nobr><code></td>
-          </tr>
-          <tr>
-            <td><code>labeledBy</code></td>
-            <td><code>AccessibleNodeList?</code></td>
-            <td><code>aria-labeledby,<br>aria-labelledby</code></td>
-          </tr>
-          <tr>
-            <td><code>level</code></td>
-            <td><code>unsigned long?</code></td>
-            <td><code><nobr>aria-level</nobr></code></td>
-          </tr>
-          <tr>
-            <td><code>live</code></td>
-            <td><code>DOMString?</code></td>
-            <td><code><nobr>aria-live</nobr></code></td>
-          </tr>
-          <tr>
-            <td><code>modal</code></td>
-            <td><code>boolean?</code></td>
-            <td><code><nobr>aria-modal</nobr></code></td>
-          </tr>
-          <tr>
-            <td><code>multiline</code></td>
-            <td><code>boolean?</code></td>
-            <td><code><nobr>aria-multiline</nobr></code></td>
-          </tr>
-          <tr>
-            <td><code>multiselectable</code></td>
-            <td><code>boolean?</code></td>
-            <td><code><nobr>aria-multiselectable</nobr></code></td>
-          </tr>
-          <tr>
-            <td><code>orientation</code></td>
-            <td><code>DOMString?</code></td>
-            <td><code><nobr>aria-orientation</nobr></code></td>
-          </tr>
-          <tr>
-            <td><code>owns</code></td>
-            <td><code>AccessibleNodeList?</code></td>
-            <td><code>aria-owns</code></td>
-          </tr>
-          <tr>
-            <td><code>placeholder</code></td>
-            <td><code>DOMString?</code></td>
-            <td><code><nobr>aria-placeholder</nobr></code></td>
-          </tr>
-          <tr>
-            <td><code>posInSet</code></td>
-            <td><code>unsigned long?</code></td>
-            <td><code><nobr>aria-posinset</nobr></code></td>
-          </tr>
-          <tr>
-            <td><code>pressed</code></td>
-            <td><code>DOMString?</code></td>
-            <td><code><nobr>aria-pressed</nobr></code></td>
-          </tr>
-          </tr>
-            <td><code>readOnly</code></td>
-            <td><code>boolean?</code></td>
-            <td><code><nobr>aria-readonly</nobr></code></td>
-          </tr>
-          <tr>
-            <td><code>relevant</code></td>
-            <td><code>DOMString?</code></td>
-            <td><code><nobr>aria-relevant</nobr></code></td>
-          </tr>
-          <tr>
-            <td><code>required</code></td>
-            <td><code>boolean?</code></td>
-            <td><code><nobr>aria-required</nobr></code></td>
-          </tr>
-          <tr>
-            <td><code>roleDescription</code></td>
-            <td><code>DOMString?</code></td>
-            <td><code><nobr>aria-roledescription</nobr></code></td>
-          </tr>
-          <tr>
-            <td><code>rowCount</code></td>
-            <td><code>long?</code></td>
-            <td><code><nobr>aria-rowcount</nobr></code></td>
-          </tr>
-          <tr>
-            <td><code>rowIndex</code></td>
-            <td><code>unsigned long?</code></td>
-            <td><code><nobr>aria-rowindex</nobr></code></td>
-          </tr>
-          <tr>
-            <td><code>rowSpan</code></td>
-            <td><code>unsigned long?</code></td>
-            <td><code><nobr>aria-rowspan</nobr></code></td>
-          </tr>
-          <tr>
-            <td><code>selected</code></td>
-            <td><code>boolean?</code></td>
-            <td><code><nobr>aria-selected</nobr></code></td>
-          </tr>
-          <tr>
-            <td><code>setSize</code></td>
-            <td><code>long?</code></td>
-            <td><code><nobr>aria-setsize</nobr></code></td>
-          </tr>
-          <tr>
-            <td><code>sort</code></td>
-            <td><code>DOMString?</code></td>
-            <td><code><nobr>aria-sort</nobr></code></td>
-          </tr>
-          <tr>
-            <td><code>valueMax</code></td>
-            <td><code>double?</code></td>
-            <td><code><nobr>aria-valuemax</nobr></code></td>
-          </tr>
-          <tr>
-            <td><code>valueMin</code></td>
-            <td><code>double?</code></td>
-            <td><code><nobr>aria-valuemin</nobr></code></td>
-          </tr>
-          <tr>
-            <td><code>valueNow</code></td>
-            <td><code>double?</code></td>
-            <td><code><nobr>aria-valuenow</nobr></code></td>
-          </tr>
-          <tr>
-            <td><code>valueText</code></td>
-            <td><code>DOMString?</code></td>
-            <td><code><nobr>aria-valuetext</nobr></code></td>
-          </tr>
-        </tbody>
-      </table>
+      <section id="computed-accessibility-tree">
+        <h2>Phase 4: Computed Accessibility Tree</h2>
+        <p>See the <a href="computed-accessibility-tree.html">Computed Accessibility Tree</a> document.</p>
       </section>
-      <section id="Types">
-        <h3>
-          Types
-        </h3>
-        <p>
-          While ARIA attributes are all strings, AccessibleNode properties
-          can have many different types. Most of these are straightforward,
-          for example <code>valueNow</code>, <code>valueMin</code>, and
-          <code>valueMax</code> are of type <code>double</code>, while
-          <code>rowCount</code> is of type <code>long</code>.
-        </p>
-        <p>
-          The primary difference is with ARIA attributes that take one
-          or more IDREFs. In AccessibleNode, they take references to
-          one or more AccessibleNodes directly. This makes it possible
-          to establish relationships between nodes that aren't in the
-          same <i>tree scope</i>, such as in different frames (with the
-          same origin), or in the shadow DOM of a custom element.
-        </p>
-        <p>
-          In particular,
-          <code>activeDescendant</code>,
-          <code>details</code>, and
-          <code>errorMessage</code>
-          are set with another AccessibleNode, while
-          <code>controls</code>,
-          <code>flowTo</code>,
-          <code>labeledBy</code>,
-          <code>describedBy</code>, and
-          <code>owns</code>
-          all take an AccessibleNodeList.
-        </p>
-      </section>
-      <section id="validation">
-        <h3>
-          Validation
-        </h3>
-        <p>
-          Upon setting a property of AccessibleNode, no validation is
-          done. The user-provided value is simply stored, converted to the
-          appropriate type via the standard rules for JavaScript types.
-          This is to
-          ensure that backwards compatibility is maintained; when a new
-          property is added or a new value is recognized as valid, authors
-          do not have to worry that browsers who have not yet added support
-          will break or throw an exception upon encountering this code.
-        </p>
-      </section>
-    </section>
-    <section id="actions">
-      <h2>
-        Phase 2: Accessible Actions
-      </h2>
-      <p>See <a href="phase2.html">Phase 2</a></p>
-    </section>
-    <section id="actions">
-      <h2>
-        Phase 3: Virtual Accessibility Nodes
-      </h2>
-      <p>See <a href="phase3.html">Phase 3</a></p>
-    </section>
-    <section id="actions">
-      <h2>
-        Phase 4: Computed Accessibility Tree
-      </h2>
-      <p>See <a href="phase4.html">Phase 4</a></p>
     </section>
     <section class="appendix">
       <h2>

--- a/spec/phase1.html
+++ b/spec/phase1.html
@@ -1,0 +1,670 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>
+      Accessibility Object Model, Phase 1
+    </title>
+    <meta charset='utf-8'>
+    <script src='https://www.w3.org/Tools/respec/respec-w3c-common' async
+    class='remove'>
+    </script>
+    <script class='remove'>
+    /*Make tidy happy*/
+    var respecConfig = {
+          // specification status (e.g. WD, LCWD, WG-NOTE, etc.). If in doubt use ED.
+          specStatus:           "unofficial",
+          // the specification's short name, as in http://www.w3.org/TR/short-name/
+          shortName:            "aom",
+
+          // if your specification has a subtitle that goes below the main
+          // formal title, define it here
+          // subtitle   :  "an excellent document",
+
+          // if you wish the publication date to be other than the last modification, set this
+          // publishDate:  "2009-08-06",
+
+          // if the specification's copyright date is a range of years, specify
+          // the start date here:
+          // copyrightStart: "2005"
+
+          // if there is a previously published draft, uncomment this and set its YYYY-MM-DD date
+          // and its maturity status
+          // previousPublishDate:  "1977-03-15",
+          // previousMaturity:  "WD",
+
+          // if there a publicly available Editor's Draft, this is the link
+          // edDraftURI:           "http://berjon.com/",
+
+          // if this is a LCWD, uncomment and set the end of its review period
+          // lcEnd: "2009-08-05",
+
+          // editors, add as many as you like
+          // only "name" is required
+          editors:  [
+              {
+                  name:       "Alice Boxhall"
+              ,   url:        "http://google.com"
+              ,   mailto:     "aboxhall@google.com"
+              ,   company:    "Google"
+              ,   companyURL: "http://google.com/"
+              },
+              {
+                  name:       "James Craig"
+              ,   url:        "http://apple.com"
+              ,   mailto:     "jcraig@apple.com"
+              ,   company:    "Apple"
+              ,   companyURL: "http://apple.com/"
+              },
+              {
+                  name:       "Dominic Mazzoni"
+              ,   url:        "http://google.com"
+              ,   mailto:     "dmazzoni@google.com"
+              ,   company:    "Google"
+              ,   companyURL: "http://google.com/"
+              },
+              {
+                  name:       "Alexander Surkov"
+              ,   url:        "http://mozilla.org/"
+              ,   mailto:     "surkov.alexander@gmail.com"
+              ,   company:    "Mozilla"
+              ,   companyURL: "http://mozilla.org/"
+              },
+          ],
+          // name of the WG
+          //         wg:           "None",
+
+          // URI of the public WG page
+          //         wgURI:        "http://example.org/really-cool-wg",
+
+          // name (without the @w3c.org) of the public mailing to which comments are due
+          //          wgPublicList: "spec-writers-anonymous",
+
+          // URI of the patent status for this WG, for Rec-track documents
+          // !!!! IMPORTANT !!!!
+          // This is important for Rec-track documents, do not copy a patent URI from a random
+          // document unless you know what you're doing. If in doubt ask your friendly neighbourhood
+          // Team Contact.
+          //        wgPatentURI:  "",
+          // !!!! IMPORTANT !!!! MAKE THE ABOVE BLINK IN YOUR HEAD
+      };
+    </script>
+    <style>
+      table{
+        border:solid 2px #999;
+        border-width:1px 0 0 1px;
+        margin:0.1em 0 1em;
+        padding:0;
+        border-spacing:0;
+        border-collapse:collapse;
+      }
+      th, td{
+        border:solid 2px #999;
+        border-width:0 1px 1px 0;
+        padding:0.15em 0.3em 0.1em;
+        /*min-width:20em;*/
+        vertical-align:top;
+        text-align:left;
+      }
+      th+th, td+td{
+        width:auto;
+      }
+      th{
+        background-color:#eee;
+      }
+      caption{
+        text-align:left;
+        color:#555;
+        font-style:normal;
+        margin:1em 0 0.1em;
+        padding:0 0 0 0.3em;
+      }
+    </style>
+  </head>
+  <body>
+    <section id='abstract'>
+      <p class="warning">
+        This spec has been deprecated,
+        please see the
+        <a href="https://github.com/WICG/aom/blob/master/explainer.md">Accessibility Object Model Explainer</a>
+        and
+        <a href="index.html">index to specs</a>
+        for up to date information.
+      </p>
+      <p>
+        This specification provides a way for authors to make web apps
+        accessible using scripting, rather than the only option being
+        declarative accessibility features of HTML markup. In the
+        first phase, the author is able to programmatically
+        modify the accessible representation of an existing DOM
+        element. In future phases, the author is able to respond to
+        additional input events from assistive technology,
+        create new virtual accessible objects on the page that don't
+        correspond to an HTML element at all, and explore the computed
+        accessibility tree.
+      </p>
+    </section>
+    <section id="introduction" class="informative">
+      <h1>Introduction</h1>
+      <section id="explainer">
+        <h2>Explainer</h2>
+        <p>
+          Please refer to the
+          <a href="https://github.com/WICG/aom/blob/master/explainer.md">
+            Accessibility Object Model Explainer</a> for the background and
+          motivation.
+        </p>
+        <p>If you have questions, comments, or other feedback, please
+          <a href="https://github.com/WICG/aom/issues">file an issue</a> on GitHub.
+        </p>
+      </section>
+      <section id="scope">
+        <h2>Document Scope</h2>
+        <p>The Accessibility Object Model spec is narrowly focused on the goal of creating a scripting API for web accessibility. It's intended to complement existing web accessibility APIs such as [[!WAI-ARIA]], not replace them. In particular, this spec attempts to avoid proposing new roles, states, and properties an of accessible objects except where necessary.</p>
+      </section>
+      <section id="inclusion">
+        <h2>Criteria for Inclusion</h2>
+        <p>This specification is not intended to solve all accessibility problems on the Web. It is currently impossible to make some web features accessible, so the primary goal is to resolve immediate needs quickly for existing, inaccessible web interfaces. The specification editors are purposefully deferring many useful ideas in order to maintain a realistic timeline for highest priority features.</p>
+        <p>
+          We have defined <a href="criteria.html">Inclusion/Exclusion Criteria</a>
+          in order to clarify exactly what will be considered in-scope.
+        </p>
+      </section>
+    </section>
+    <section id="properties">
+      <h2>
+        Phase 1: Accessible Properties
+      </h2>
+      <section>
+        <h3>
+          Extensions to the <code>Element</code> interface
+        </h3>
+        <p>
+          The author can request an <i>accessible node</i> from any valid [[!DOM]]
+          <code>Element</code>.
+        </p>
+        <pre class="idl">
+          partial interface Element {
+            readonly attribute AccessibleNode accessibleNode;
+          };
+        </pre>
+        <p data-dfn-for="Element">
+          The <dfn>accessibleNode</dfn> attribute returns the <i>accessible
+          node</i> associated with this <code>DOM element</code>. It always returns
+          a valid object if the browser supports the AOM.
+        </p>
+      </section>
+      <section id="accessiblenode">
+        <h3>
+          <code>AccessibleNode</code> interface
+        </h3>
+        <pre class="idl">
+        interface AccessibleNode {
+          attribute DOMString? role;
+          attribute DOMString? roleDescription;
+
+          // Accessible label and description.
+          attribute DOMString? label;
+          attribute AccessibleNodeList? labeledBy;
+          attribute AccessibleNodeList? describedBy;
+
+          // Global states and properties.
+          attribute DOMString? current;
+
+          // Widget properties.
+          attribute DOMString? autocomplete;
+          attribute boolean? hidden;
+          attribute DOMString? keyShortcuts;
+          attribute boolean? modal;
+          attribute boolean? multiline;
+          attribute boolean? multiselectable;
+          attribute DOMString? orientation;
+          attribute boolean? readOnly;
+          attribute boolean? required;
+          attribute boolean? selected;
+          attribute DOMString? sort;
+
+          // Widget states.
+          attribute DOMString? checked;
+          attribute boolean? expanded;
+          attribute boolean? disabled;
+          attribute DOMString? invalid;
+          attribute DOMString? hasPopUp;
+          attribute DOMString? pressed;
+
+          // Control values.
+          attribute DOMString? valueText;
+          attribute DOMString? placeholder;
+          attribute double? valueNow;
+          attribute double? valueMin;
+          attribute double? valueMax;
+
+          // Live regions.
+          attribute boolean? atomic;
+          attribute boolean? busy;
+          attribute DOMString? live;
+          attribute DOMString? relevant;
+
+          // Other relationships.
+          attribute AccessibleNode? activeDescendant;
+          attribute AccessibleNodeList? controls;
+          attribute AccessibleNode? details;
+          attribute AccessibleNode? errorMessage;
+          attribute AccessibleNodeList? flowTo;
+          attribute AccessibleNodeList? owns;
+
+          // Collections.
+          attribute long? colCount;
+          attribute unsigned long? colIndex;
+          attribute unsigned long? colSpan;
+          attribute unsigned long? posInSet;
+          attribute long? rowCount;
+          attribute unsigned long? rowIndex;
+          attribute unsigned long? rowSpan;
+          attribute long? setSize;
+          attribute unsigned long? level;
+        };
+        </pre>
+        <p>
+          Initially all AccessibleNode properties must return null.
+        </p>
+        <p>
+          All AccessibleNode properties, on setting, store the provided value.
+          On getting, they return the user-provided value if present and valid,
+          and null otherwise. The validity of a property valid is specified in
+          greater detail below.
+        </p>
+        <p>
+          Values set on a DOM element's AccessibleNode are used
+          for the browser's implementation of native accessibility APIs for
+          that accessibility property.
+          When both an AccessibleNode property and its equivalent ARIA attribute
+          are both present, the ARIA attribute overrides the AccessibleNode
+          property.
+        </p>
+        <p>
+          If a property of AccessibleNode is set to an invalid value, it is ignored.
+        </p>
+      </section>
+      <section>
+        <h3>
+          <code>AccessibleNodeList</code> interface
+        </h3>
+        <p>
+          An <code>AccessibleNodeList</code> represents an ordered
+          list of AccessibleNodes.
+          It's used to represent relationships between one
+          <code>AccessibleNode</code> and other
+          <code>AccessibleNodes</code> in the accessibility tree.
+          Unlike <code>AccessibleNode</code>, <code>AccessibleNodeList</code>
+          has a constructor.
+        </p>
+        <pre class="idl">
+        [
+          Constructor(optional sequence&lt;AccessibleNode&gt; nodes = [])
+        ]
+        interface AccessibleNodeList {
+          attribute unsigned long length;
+          getter AccessibleNode? item(unsigned long index);
+          setter void (unsigned long index, AccessibleNode node);
+          void add(AccessibleNode node, optional AccessibleNode? before = null);
+          void remove(long index);
+        };
+        </pre>
+      </section>
+      <section id="mapping">
+        <h3>
+          Mapping to ARIA attributes
+        </h3>
+        <p>
+          In Phase 1, there's a 1:1 correspondence between the set of
+          properties on AccessibleNode and the list of valid ARIA
+          attributes from the [[!WAI-ARIA]] 1.1 spec.
+          This table shows the mappings and also includes deprecated
+          ARIA attributes that are not mapped into AccessibleNode
+          properties.
+        </p>
+        <p>
+          The Accessibility Object Model does not define new semantics.
+          The semantic meaning of each AccessibleNode property
+          is identical to the meaning of the ARIA attribute.
+        </p>
+      <table>
+        <caption>
+          <dfn>Accessibility property table</dfn>
+        </caption>
+        <thead>
+          <tr>
+            <th>Attribute name</th>
+            <th>Type</th>
+            <th>Equivalent ARIA attribute</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>activeDescendant</code></td>
+            <td><code>AccessibleNode?</code></td>
+            <td><code>aria-activedescendant</code></td>
+          </tr>
+          <tr>
+            <td><code>atomic</code></td>
+            <td><code>boolean?</code></td>
+            <td><code>aria-atomic</code></td>
+          </tr>
+          <tr>
+            <td><code>autocomplete</code></td>
+            <td><code>DOMString?</code></td>
+            <td><code><nobr>aria-autocomplete</nobr></code></td>
+          </tr>
+          <tr>
+            <td><code>busy</code></td>
+            <td><code>boolean?</code></td>
+            <td><code>aria-busy</code></td>
+          </tr>
+          <tr>
+            <td><code>checked</code></td>
+            <td><code>DOMString?</code></td>
+            <td><code><nobr>aria-checked</nobr></code></td>
+          </tr>
+          <tr>
+            <td><code>colCount</code></td>
+            <td><code>long?</code></td>
+            <td><code><nobr>aria-colcount</nobr></code></td>
+          </tr>
+          <tr>
+            <td><code>colIndex</code></td>
+            <td><code>unsigned long?</code></td>
+            <td><code><nobr>aria-colindex</nobr></code></td>
+          </tr>
+          <tr>
+            <td><code>colSpan</code></td>
+            <td><code>unsigned long?</code></td>
+            <td><code><nobr>aria-colSpan</nobr></code></td>
+          </tr>
+          <tr>
+            <td><code>controls</code></td>
+            <td><code>AccessibleNodeList?</code></td>
+            <td><code>aria-controls</code></td>
+          </tr>
+          <tr>
+            <td><code>current</code></td>
+            <td><code>DOMString?</code></td>
+            <td><code><nobr>aria-current</nobr></code></td>
+          </tr>
+          <tr>
+            <td><code>describedBy</code></td>
+            <td><code>AccessibleNodeList?</code></td>
+            <td><code>aria-describedby</code></td>
+          </tr>
+          <tr>
+            <td><code>details</code></td>
+            <td><code>AccessibleNode?</code></td>
+            <td><code>aria-details</code></td>
+          </tr>
+          <tr>
+            <td><code>disabled</code></td>
+            <td><code>boolean?</code></td>
+            <td><code><nobr>aria-disabled</nobr></code></td>
+          </tr>
+          <tr>
+            <td></td>
+            <td></td>
+            <td><code><nobr>aria-dropeffect</nobr></code>
+              (deprecated)
+            </td>
+          </tr>
+          <tr>
+            <td><code>errorMessage</code></td>
+            <td><code>AccessibleNode?</code></td>
+            <td><code>aria-errormessage</code></td>
+          </tr>
+          <tr>
+            <td><code>expanded</code></td>
+            <td><code>boolean?</code></td>
+            <td><code><nobr>aria-expanded</nobr></code></td>
+          </tr>
+          <tr>
+            <td><code>flowTo</code></td>
+            <td><code>AccessibleNodeList?</code></td>
+            <td><code>aria-flowto</code></td>
+          </tr>
+          <tr>
+            <td></td>
+            <td></td>
+            <td><code><nobr>aria-grabbed</nobr></code>
+              (deprecated)
+            </td>
+          </tr>
+          <tr>
+            <td><code>hasPopUp</code></td>
+            <td><code>DOMString?</code></td>
+            <td><code><nobr>aria-haspopup</nobr></code></td>
+          </tr>
+          <tr>
+            <td><code>hidden</code></td>
+            <td><code>boolean?</code></td>
+            <td><code><nobr>aria-hidden</nobr></code></td>
+          </tr>
+          <tr>
+            <td><code>invalid</code></td>
+            <td><code>DOMString?</code></td>
+            <td><code><nobr>aria-invalid</nobr></code></td>
+          </tr>
+          <tr>
+            <td><code>keyShortcuts</code></td>
+            <td><code>DOMString?</code></td>
+            <td><code><nobr>aria-keyshortcuts</nobr></code></td>
+          </tr>
+          <tr>
+            <td><code>label</code></td>
+            <td><code>DOMString?</code></td>
+            <td><code><nobr>aria-label</nobr><code></td>
+          </tr>
+          <tr>
+            <td><code>labeledBy</code></td>
+            <td><code>AccessibleNodeList?</code></td>
+            <td><code>aria-labeledby,<br>aria-labelledby</code></td>
+          </tr>
+          <tr>
+            <td><code>level</code></td>
+            <td><code>unsigned long?</code></td>
+            <td><code><nobr>aria-level</nobr></code></td>
+          </tr>
+          <tr>
+            <td><code>live</code></td>
+            <td><code>DOMString?</code></td>
+            <td><code><nobr>aria-live</nobr></code></td>
+          </tr>
+          <tr>
+            <td><code>modal</code></td>
+            <td><code>boolean?</code></td>
+            <td><code><nobr>aria-modal</nobr></code></td>
+          </tr>
+          <tr>
+            <td><code>multiline</code></td>
+            <td><code>boolean?</code></td>
+            <td><code><nobr>aria-multiline</nobr></code></td>
+          </tr>
+          <tr>
+            <td><code>multiselectable</code></td>
+            <td><code>boolean?</code></td>
+            <td><code><nobr>aria-multiselectable</nobr></code></td>
+          </tr>
+          <tr>
+            <td><code>orientation</code></td>
+            <td><code>DOMString?</code></td>
+            <td><code><nobr>aria-orientation</nobr></code></td>
+          </tr>
+          <tr>
+            <td><code>owns</code></td>
+            <td><code>AccessibleNodeList?</code></td>
+            <td><code>aria-owns</code></td>
+          </tr>
+          <tr>
+            <td><code>placeholder</code></td>
+            <td><code>DOMString?</code></td>
+            <td><code><nobr>aria-placeholder</nobr></code></td>
+          </tr>
+          <tr>
+            <td><code>posInSet</code></td>
+            <td><code>unsigned long?</code></td>
+            <td><code><nobr>aria-posinset</nobr></code></td>
+          </tr>
+          <tr>
+            <td><code>pressed</code></td>
+            <td><code>DOMString?</code></td>
+            <td><code><nobr>aria-pressed</nobr></code></td>
+          </tr>
+          </tr>
+            <td><code>readOnly</code></td>
+            <td><code>boolean?</code></td>
+            <td><code><nobr>aria-readonly</nobr></code></td>
+          </tr>
+          <tr>
+            <td><code>relevant</code></td>
+            <td><code>DOMString?</code></td>
+            <td><code><nobr>aria-relevant</nobr></code></td>
+          </tr>
+          <tr>
+            <td><code>required</code></td>
+            <td><code>boolean?</code></td>
+            <td><code><nobr>aria-required</nobr></code></td>
+          </tr>
+          <tr>
+            <td><code>roleDescription</code></td>
+            <td><code>DOMString?</code></td>
+            <td><code><nobr>aria-roledescription</nobr></code></td>
+          </tr>
+          <tr>
+            <td><code>rowCount</code></td>
+            <td><code>long?</code></td>
+            <td><code><nobr>aria-rowcount</nobr></code></td>
+          </tr>
+          <tr>
+            <td><code>rowIndex</code></td>
+            <td><code>unsigned long?</code></td>
+            <td><code><nobr>aria-rowindex</nobr></code></td>
+          </tr>
+          <tr>
+            <td><code>rowSpan</code></td>
+            <td><code>unsigned long?</code></td>
+            <td><code><nobr>aria-rowspan</nobr></code></td>
+          </tr>
+          <tr>
+            <td><code>selected</code></td>
+            <td><code>boolean?</code></td>
+            <td><code><nobr>aria-selected</nobr></code></td>
+          </tr>
+          <tr>
+            <td><code>setSize</code></td>
+            <td><code>long?</code></td>
+            <td><code><nobr>aria-setsize</nobr></code></td>
+          </tr>
+          <tr>
+            <td><code>sort</code></td>
+            <td><code>DOMString?</code></td>
+            <td><code><nobr>aria-sort</nobr></code></td>
+          </tr>
+          <tr>
+            <td><code>valueMax</code></td>
+            <td><code>double?</code></td>
+            <td><code><nobr>aria-valuemax</nobr></code></td>
+          </tr>
+          <tr>
+            <td><code>valueMin</code></td>
+            <td><code>double?</code></td>
+            <td><code><nobr>aria-valuemin</nobr></code></td>
+          </tr>
+          <tr>
+            <td><code>valueNow</code></td>
+            <td><code>double?</code></td>
+            <td><code><nobr>aria-valuenow</nobr></code></td>
+          </tr>
+          <tr>
+            <td><code>valueText</code></td>
+            <td><code>DOMString?</code></td>
+            <td><code><nobr>aria-valuetext</nobr></code></td>
+          </tr>
+        </tbody>
+      </table>
+      </section>
+      <section id="Types">
+        <h3>
+          Types
+        </h3>
+        <p>
+          While ARIA attributes are all strings, AccessibleNode properties
+          can have many different types. Most of these are straightforward,
+          for example <code>valueNow</code>, <code>valueMin</code>, and
+          <code>valueMax</code> are of type <code>double</code>, while
+          <code>rowCount</code> is of type <code>long</code>.
+        </p>
+        <p>
+          The primary difference is with ARIA attributes that take one
+          or more IDREFs. In AccessibleNode, they take references to
+          one or more AccessibleNodes directly. This makes it possible
+          to establish relationships between nodes that aren't in the
+          same <i>tree scope</i>, such as in different frames (with the
+          same origin), or in the shadow DOM of a custom element.
+        </p>
+        <p>
+          In particular,
+          <code>activeDescendant</code>,
+          <code>details</code>, and
+          <code>errorMessage</code>
+          are set with another AccessibleNode, while
+          <code>controls</code>,
+          <code>flowTo</code>,
+          <code>labeledBy</code>,
+          <code>describedBy</code>, and
+          <code>owns</code>
+          all take an AccessibleNodeList.
+        </p>
+      </section>
+      <section id="validation">
+        <h3>
+          Validation
+        </h3>
+        <p>
+          Upon setting a property of AccessibleNode, no validation is
+          done. The user-provided value is simply stored, converted to the
+          appropriate type via the standard rules for JavaScript types.
+          This is to
+          ensure that backwards compatibility is maintained; when a new
+          property is added or a new value is recognized as valid, authors
+          do not have to worry that browsers who have not yet added support
+          will break or throw an exception upon encountering this code.
+        </p>
+      </section>
+    </section>
+    <section id="actions">
+      <h2>
+        Phase 2: Accessible Actions
+      </h2>
+      <p>See <a href="phase2.html">Phase 2</a></p>
+    </section>
+    <section id="actions">
+      <h2>
+        Phase 3: Virtual Accessibility Nodes
+      </h2>
+      <p>See <a href="phase3.html">Phase 3</a></p>
+    </section>
+    <section id="actions">
+      <h2>
+        Phase 4: Computed Accessibility Tree
+      </h2>
+      <p>See <a href="phase4.html">Phase 4</a></p>
+    </section>
+    <section class="appendix">
+      <h2>
+        Acknowledgements
+      </h2>
+      <p>
+        Many thanks for valuable feedback, advice, and tools from:
+        Alex Russell, Bogdan Brinza, Chris Fleizach, Cynthia Shelley, David Bolter, Domenic Denicola, Ian Hickson, Joanmarie Diggs, Marcos Caceres, Nan Wang, Robin Berjon, and Tess O'Connor.
+      </p>
+      <p>
+        Bogdan Brinza and Cynthia Shelley of Microsoft contributed to the first draft of this spec but are no longer actively participating.
+      </p>
+    </section>
+  </body>
+</html>

--- a/spec/phase2.html
+++ b/spec/phase2.html
@@ -90,6 +90,16 @@
     </script>
   </head>
   <body>
+    <section id="abstract">
+      <p class="warning">
+        This spec has been deprecated,
+        please see the
+        <a href="https://github.com/WICG/aom/blob/master/explainer.md">Accessibility Object Model Explainer</a>
+        and
+        <a href="index.html">index to specs</a>
+        for up to date information.
+      </p>
+    </section>
     <section id="introduction">
       <h1>Introduction</h1>
       <p>

--- a/spec/phase4.html
+++ b/spec/phase4.html
@@ -90,6 +90,16 @@
     </script>
   </head>
   <body>
+    <section id="abstract">
+      <p class="warning">
+        This spec has been deprecated,
+        please see the
+        <a href="https://github.com/WICG/aom/blob/master/explainer.md">Accessibility Object Model Explainer</a>
+        and
+        <a href="index.html">index to specs</a>
+        for up to date information.
+      </p>
+    </section>
     <section id="introduction">
       <h1>Introduction</h1>
       <p>

--- a/spec/user-action-events.html
+++ b/spec/user-action-events.html
@@ -3,7 +3,7 @@
 
 <head>
   <title>
-    Accessibility Object Model, Phase 3
+    Accessibility Object Model, Phase 2
   </title>
   <meta charset='utf-8'>
   <script src='https://www.w3.org/Tools/respec/respec-w3c-common' async class='remove'>
@@ -92,52 +92,14 @@
 
 <body>
   <section id="abstract">
-        <p>
-      This document is a placeholder for the spec for "Virtual Accessibility Nodes", a part of the AOM project. For background, please refer to the
-      <a href="https://github.com/WICG/aom/blob/master/explainer.md">Accessibility Object Model Explainer</a> for the background and motivation.
+    <p>
+      This document is a placeholder for
+      the spec for "User Action Events",
+      a part of the AOM project.
+      For background, please refer to the
+      <a href="https://github.com/WICG/aom/blob/master/explainer.md">Accessibility Object Model Explainer</a>.
     </p>
   </section>
-  <section class="virtual">
-    <h2>
-      Virtual Accessibility Nodes
-    </h2>
-    <p>
-      Virtual Accessibility Nodes will allow authors to expose "virtual" accessibility nodes, which are not associated directly
-      with any particular DOM node, to assistive technology.
-    </p>
-    <p>
-      This mechanism is often present in native accessibility APIs, in order to allow authors more granular control over the accessibility
-      of custom-drawn APIs.
-    </p>
-    <p>
-      On the web, this would allow:
-      <ul>
-        <li>creating an accessible alternative to canvas-based UI which does not rely on fallback or visually-hidden DOM content.</li>
-        <li>adding semantic information to other types of non-DOM based UI, such as a remote desktop implementation using a
-          <code>&lt;video&gt;</code> element, or another novel form of UI presentation.</li>
-      </ul>
-    </p>
-  </section>
-  <section>
-    <!--
-Look at:
-- https://html.spec.whatwg.org/multipage/media.html#texttrack
-- https://developer.mozilla.org/en-US/docs/Web/API/AudioNode
-
-Do we need to have three+ AccessibleNode types?
-
-interface AccessibleNode : EventTarget {
-  // Virtual type, tree walking only (cf. DOM node)
-}
-
-interface AccessibleRoot : AccessibleNode {
-  // bridge between DOM and AccessibleNode tree
-}
-
-interface VirtualAccessibleNode : AccessibleNode {
-  // All the properties
-}
-      -->
 </body>
 
 </html>

--- a/spec/virtual-accessibility-nodes.html
+++ b/spec/virtual-accessibility-nodes.html
@@ -1,0 +1,166 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <title>
+    Accessibility Object Model, Phase 3
+  </title>
+  <meta charset='utf-8'>
+  <script src='https://www.w3.org/Tools/respec/respec-w3c-common' async class='remove'>
+  </script>
+  <script class='remove'>
+    /*Make tidy happy*/
+    var respecConfig = {
+      // specification status (e.g. WD, LCWD, WG-NOTE, etc.). If in doubt use ED.
+      specStatus: "unofficial",
+      // the specification's short name, as in http://www.w3.org/TR/short-name/
+      shortName: "aom",
+
+      // if your specification has a subtitle that goes below the main
+      // formal title, define it here
+      // subtitle   :  "an excellent document",
+
+      // if you wish the publication date to be other than the last modification, set this
+      // publishDate:  "2009-08-06",
+
+      // if the specification's copyright date is a range of years, specify
+      // the start date here:
+      // copyrightStart: "2005"
+
+      // if there is a previously published draft, uncomment this and set its YYYY-MM-DD date
+      // and its maturity status
+      // previousPublishDate:  "1977-03-15",
+      // previousMaturity:  "WD",
+
+      // if there a publicly available Editor's Draft, this is the link
+      // edDraftURI:           "http://berjon.com/",
+
+      // if this is a LCWD, uncomment and set the end of its review period
+      // lcEnd: "2009-08-05",
+
+      // editors, add as many as you like
+      // only "name" is required
+      editors: [
+        {
+          name: "Alice Boxhall"
+          , url: "http://google.com"
+          , mailto: "aboxhall@google.com"
+          , company: "Google"
+          , companyURL: "http://google.com/"
+        },
+        {
+          name: "James Craig"
+          , url: "http://apple.com"
+          , mailto: "jcraig@apple.com"
+          , company: "Apple"
+          , companyURL: "http://apple.com/"
+        },
+        {
+          name: "Dominic Mazzoni"
+          , url: "http://google.com"
+          , mailto: "dmazzoni@google.com"
+          , company: "Google"
+          , companyURL: "http://google.com/"
+        },
+        {
+          name: "Alexander Surkov"
+          , url: "http://mozilla.org/"
+          , mailto: "surkov.alexander@gmail.com"
+          , company: "Mozilla"
+          , companyURL: "http://mozilla.org/"
+        },
+      ],
+      // name of the WG
+      //         wg:           "None",
+
+      // URI of the public WG page
+      //         wgURI:        "http://example.org/really-cool-wg",
+
+      // name (without the @w3c.org) of the public mailing to which comments are due
+      //          wgPublicList: "spec-writers-anonymous",
+
+      // URI of the patent status for this WG, for Rec-track documents
+      // !!!! IMPORTANT !!!!
+      // This is important for Rec-track documents, do not copy a patent URI from a random
+      // document unless you know what you're doing. If in doubt ask your friendly neighbourhood
+      // Team Contact.
+      //        wgPatentURI:  "",
+      // !!!! IMPORTANT !!!! MAKE THE ABOVE BLINK IN YOUR HEAD
+    };
+  </script>
+</head>
+
+<body>
+  <section id="introduction">
+    <h1>Introduction</h1>
+    <p>
+      This document is the spec for "Virtual Accessibility Nodes", a part of the AOM project. For background, please refer to the
+      <a href="https://github.com/WICG/aom/blob/master/explainer.md">Accessibility Object Model Explainer</a> for the background and motivation.
+    </p>
+  </section>
+  <section class="virtual">
+    <h2>
+      Virtual Accessibility Nodes
+    </h2>
+    <p>
+      Virtual Accessibility Nodes will allow authors to expose "virtual" accessibility nodes, which are not associated directly
+      with any particular DOM node, to assistive technology.
+    </p>
+    <p>
+      This mechanism is often present in native accessibility APIs, in order to allow authors more granular control over the accessibility
+      of custom-drawn APIs.
+    </p>
+    <p>
+      On the web, this would allow:
+      <ul>
+        <li>creating an accessible alternative to canvas-based UI which does not rely on fallback or visually-hidden DOM content.</li>
+        <li>adding semantic information to other types of non-DOM based UI, such as a remote desktop implementation using a
+          <code>&lt;video&gt;</code> element, or another novel form of UI presentation.</li>
+      </ul>
+    </p>
+  </section>
+  <section>
+    <!--
+Look at:
+- https://html.spec.whatwg.org/multipage/media.html#texttrack
+- https://developer.mozilla.org/en-US/docs/Web/API/AudioNode
+
+Do we need to have three+ AccessibleNode types?
+
+interface AccessibleNode : EventTarget {
+  // Virtual type, tree walking only (cf. DOM node)
+}
+
+interface AccessibleRoot : AccessibleNode {
+  // bridge between DOM and AccessibleNode tree
+}
+
+interface VirtualAccessibleNode : AccessibleNode {
+  // All the properties
+}
+      -->
+    <h3>
+      Extensions to the
+      <code>Element</code> interface
+    </h3>
+    <p>
+      The author can attach an
+      <code>AccessibleRoot</code> from any valid [[!DOM]]
+      <code>Element</code>.
+    </p>
+    <pre class="idl">
+partial interface Element {
+  AccessibleNode accessibleNode;
+};
+</pre>
+    <p data-dfn-for="Element">
+      The
+      <dfn>accessibleNode</dfn> attribute returns the
+      <i>accessible node
+      </i> associated with this
+      <code>DOM element</code>. It always returns a valid object if the browser supports the AOM.
+    </p>
+  </section>
+</body>
+
+</html>


### PR DESCRIPTION
aria-reflection.html has a stab at explaining the Element and ShadowRoot interfaces, largely taken from @cookiecrook's existing change to the ARIA spec.

virtual-accessibility-nodes.html is little more than a placeholder at this point.