### PR TITLE
fix How to enable AOM

### DIFF
--- a/caniuse.md
+++ b/caniuse.md
@@ -4,14 +4,11 @@ Track the implementation status of the AOM in various browsers.
 
 ## How to enable AOM
 
-*Chrome*:
-```--enable-blink-features=AccessibilityObjectModel```
+*Chrome*: `--enable-blink-features=AccessibilityObjectModel`
 
-*Safari Technology Preview*:
-```Develop > Experimental Features > Accessibility Object Model```
+*Safari Technology Preview*: `Develop > Experimental Features > Accessibility Object Model`
 
-*Firefox*:
-```about:config accessibility.AOM.enabled = true```
+*Firefox*: `about:config accessibility.AOM.enabled = true`
 
 ## Summary
 


### PR DESCRIPTION
"How to enable AOM" section's rendering is broken in `.html` as below.

<img width="375" alt="screen shot how to enable aom section" src="https://user-images.githubusercontent.com/6724665/47725474-f8fa6080-dc9b-11e8-9df1-9eaad72b0053.png" />
