### PR TITLE
Fix markdown issues affecting rendered caniuse.html

### DIFF
--- a/caniuse.md
+++ b/caniuse.md
@@ -5,17 +5,20 @@ Track the implementation status of the AOM in various browsers.
 ## How to enable AOM
 
 **Chrome**:
-*For `AccessibleNode`/`ComputedAccessibleNode`-related features:*
-```--enable-blink-features=AccessibilityObjectModel```
+
+*For `AccessibleNode`/`ComputedAccessibleNode`-related features:*<br>
+`--enable-blink-features=AccessibilityObjectModel`
 
 *For web platform related features:*
 Browse to `chrome://flags`, enable `enable-experimental-web-platform-features`.
 
 **Safari Technology Preview**:
-```Develop > Experimental Features > Accessibility Object Model```
+
+`Develop > Experimental Features > Accessibility Object Model`
 
 **Firefox**:
-```about:config accessibility.AOM.enabled = true```
+
+`about:config accessibility.AOM.enabled = true`
 
 ## Summary
 
@@ -137,7 +140,7 @@ customSlider.addEventListener("decrement", function(event) {
 
 *Chrome (out of date syntax, pass `--enable-blink-features=AccessibilityObjectModel`)*:
 
-```
+```js
 var listitem = new AccessibleNode();
 listitem.role = "listitem";
 listitem.offsetParent = list.accessibleNode;
@@ -154,13 +157,14 @@ list.accessibleNode.appendChild(listitem);
 
 *Chrome (speculative syntax, pass `--enable-blink-features=AccessibilityObjectModel`)*:
 
-```
+```js
 var c = await window.getComputedAccessibleNode(element);
 console.log(c.role);
 console.log(c.label);
 ```
 
 *Firefox (out of date syntax)*:
-```
+
+```js
 console.log(element.accessibleNode.computedRole);
 ```


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6257356/66774053-9b502b80-ee8e-11e9-9125-372f0cdeb957.png)

Even though GitHub’s preview shows the markdown as intended, the [rendered HTML view](https://wicg.github.io/aom/caniuse.html) seems to rely on a markdown parser which treats three-backticks code blocks that start and end on a single line differently. It consumes all the text on the line after the first three backticks as a language name. I believe switching to single backticks fixes it (though I needed a `<br>` to preserve preventing a linebreak in the middle of the Chrome flag).

This also adds missing js language tags to later fenced code blocks.