### PR TITLE
Fix aria-controls typo

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -239,7 +239,7 @@ to express semantics which are implicit for native elements.
     >Tab 1</custom-tab
   >
   <custom-tab role="tab" aria-controls="tabpanel-2">Tab 2</custom-tab>
-  <custom-tab role="tab" aria-controle="tabpanel-3">Tab 3</custom-tab>
+  <custom-tab role="tab" aria-controls="tabpanel-3">Tab 3</custom-tab>
 </custom-tablist>
 ```
 


### PR DESCRIPTION
This fixes a possible typo in `explainer.md`, where `aria-controls` is written as `aria-controle`.