### PR TITLE
Update and clarify Notification API

### DIFF
--- a/notification-api.md
+++ b/notification-api.md
@@ -159,8 +159,8 @@ that should be announced beyond the immediate effect of the primary action.
 ## Proposed Solution
 
 We provide an API on Documents and Elements to enable posting imperative notifications with 
-independently-managable queues. Additionally, Element-based context should be assumed for
-language.
+independently-managable queues. Additionally, the language of the notification is based on the
+element on which the notification is sent from (or the language defaults for the document).
 
 ```js
 // Queue a message to the body element's notification queue given the provided string
@@ -172,7 +172,7 @@ glowing blue". For users without assistive technology tools running, nothing wou
 The call to the API has no web-observable side effects and its use should not infer that the 
 user is using assistive technology. 
 
-The API can also be called on the document. The document also has a single [indpendent] queue
+The API can also be called on the document. The document also has a single (independent) queue
 for notifications:
 
 ```js

--- a/notification-api.md
+++ b/notification-api.md
@@ -184,7 +184,9 @@ document.ariaNotify( "Text copied to clipboard." );
 Each element (and the document) has a unique queue for notifications. There are some affordances
 for managing these queues and the notifications that go into them (see below). It is implementation-
 dependent how all the various queues are serviced (e.g., round-robin, random selection, FIFO, DOM order),
-though they should all be serviced on one "thread" so as to avoid race-conditions.
+though they should all be serviced as part of one 
+[agent](https://html.spec.whatwg.org/multipage/webappapis.html#agents-and-agent-clusters) so as to avoid 
+race-conditions.
 
 The API offers two additional options for managing *the current node's* notification queue:
 * `placeInQueue` - how to insert the notification into the queue (at the end, at the start, or to 

--- a/notification-api.md
+++ b/notification-api.md
@@ -218,7 +218,8 @@ we aren't pursing a richer text format at this time.
 
 ### "Earcons"
 
-Supporting non-textual notficiations? We see the value in having a set of known,
+"Earcons" are short audio cues used to convey contextual information in the way that
+icons provide meaning for sighted users. We see the value in having a set of known,
 standardized (enum) values that can be associated with notification audio queues--
 generic enough to be used across many scenarios, but scoped enough to be easily 
 configurable by a user in their favorite screen reader.


### PR DESCRIPTION
After some recent internal experiementation and research into other ATs and a variety of offline feedback, we're updating our proposal. Notable changes include:
* API `ariaNotify` now supported on elements (not just the document)
* Lots of clarity on the queuing behaviors and control surface for web authors