### PR TITLE
Add GitHub link to AOM spec

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -15,6 +15,11 @@
           specStatus:           "unofficial",
           // the specification's short name, as in http://www.w3.org/TR/short-name/
           shortName:            "aom",
+          // the specification's repo
+          github: {
+              branch: "gh-pages"
+          ,   repoURL: "WICG/aom"
+          },
 
           // if your specification has a subtitle that goes below the main
           // formal title, define it here


### PR DESCRIPTION
At the moment, it's hard to find where the repo actually is from the spec.