### PR TITLE
Fix links in explainer

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -531,7 +531,7 @@ Not yet specced or implemented anywhere.
 
 ### Full Introspection of an Accessibility Tree - `ComputedAccessibleNode`
 
-This API is still being considered as part of [Issue #197](/WICG/aom/issues/197).
+This API is still being considered as part of [Issue #197](https://github.com/WICG/aom/issues/197).
 
 It may be approached initially as a testing-only API.
 
@@ -565,7 +565,7 @@ This could make it possible to:
 ##### WebDriver (Shipping in WebKit/Chrome, [implemented 20 Mar 2023 in Gecko](https://bugzilla.mozilla.org/show_bug.cgi?id=1585622#c22))
  - [computedrole](https://www.w3.org/TR/webdriver/#dfn-get-computed-role)
  - [computedlabel](https://www.w3.org/TR/webdriver/#dfn-get-computed-label)
- - Some discussion of [`getComputedAccessibilityNode` (and parent/children) for tree access](/WICG/aom/issues/197)
+ - Some discussion of [`getComputedAccessibilityNode` (and parent/children) for tree access](https://github.com/WICG/aom/issues/197)
  
 ##### WPT TestDriver (functional as of March 2023)
 Leverages WebDriver accessors for ease of test development.
@@ -658,7 +658,7 @@ These issues prompted a reassessment,
 and a simplification of the API based around the original set of use cases
 we were committed to addressing.
 
-[Update: April 2023] This is being reconsidered as a test-only API in [Issue #197](/WICG/aom/issues/197)
+[Update: April 2023] This is being reconsidered as a test-only API in [Issue #197](https://github.com/WICG/aom/issues/197)
 
 ## Next Steps
 


### PR DESCRIPTION
GitHub Flavored Markdown practically requires absolute URLs