### PR TITLE
Update notification-api with link to up-to-date explainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Read the [Spec](https://wicg.github.io/aom/spec/) - note, not up-to-date
 
 ## Accessibility (ARIA) Notification API
 
+**Note notification-api.md is outdated. For the up-to-date explainer of this initiative, please [click here](https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/main/Accessibility/AriaNotify/explainer.md).**
+
 This effort aims to create a JavaScript API to allow developers to
 initiate notifications that confirm user actions (not necessarily tied 
 to direct UI changes).

--- a/README.md
+++ b/README.md
@@ -33,8 +33,10 @@ to direct UI changes).
 
 ### Editors:
 
+* Sara Tang, Microsoft, sartang@microsoft.com
+* Doug Geoffray, Microsoft, doug.geoffray@microsoft.com
+* Alison Maher, Microsoft, almaher@microsoft.com
 * Travis Leithead, Microsoft, travil@microsoft.com
-* Sara Tang, Microsoft
 * Daniel Libby, Microsoft
 
 ### Details

--- a/notification-api.md
+++ b/notification-api.md
@@ -2,8 +2,8 @@
 **Note: This explainer is no longer being maintained. For the most up-to-date version of this feature, please [click here](https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/main/Accessibility/AriaNotify/explainer.md).**
 
 Authors: 
-* [Daniel Libby](https://github.com/dlibby-), Microsoft
 * [Sara Tang](https://github.com/sartang), Microsoft
+* [Daniel Libby](https://github.com/dlibby-), Microsoft
 * [Travis Leithead](https://github.com/travisleithead), Microsoft
 
 

--- a/notification-api.md
+++ b/notification-api.md
@@ -1,4 +1,5 @@
 # Accessibility (ARIA) Notification API
+**Note: This explainer is no longer being maintained. For the most up-to-date version of this feature, please [click here](https://github.com/WICG/accessible-notifications).**
 
 Authors: 
 * [Daniel Libby](https://github.com/dlibby-), Microsoft

--- a/notification-api.md
+++ b/notification-api.md
@@ -1,5 +1,5 @@
 # Accessibility (ARIA) Notification API
-**Note: This explainer is no longer being maintained. For the most up-to-date version of this feature, please [click here](https://github.com/WICG/accessible-notifications).**
+**Note: This explainer is no longer being maintained. For the most up-to-date version of this feature, please [click here](https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/main/Accessibility/AriaNotify/explainer.md).**
 
 Authors: 
 * [Daniel Libby](https://github.com/dlibby-), Microsoft


### PR DESCRIPTION
We are picking up the accessible notifications API again. Added a link to notification-api.md to the up-to-date explaiern on MSEdgeExplainers.